### PR TITLE
fix canvas not registering correctly mouse positon

### DIFF
--- a/src/components/SoundTimeline/index.tsx
+++ b/src/components/SoundTimeline/index.tsx
@@ -202,7 +202,7 @@ function SoundTimeline(props: any) {
   const getInputPos = (e: any): Point => {
     if (rect) return {
       x: e.pageX, // - rect.left,
-      y: e.pageY - rect.top
+      y: e.clientY - rect.top
     }
     return { x: -1, y: -1 }
   }

--- a/src/components/VolumeTimeline/index.tsx
+++ b/src/components/VolumeTimeline/index.tsx
@@ -128,7 +128,7 @@ function VolumeTimeline(props: any) {
   const getInputPos = (e: any): Point => {
     if (rect) return {
       x: e.pageX - rect.left,
-      y: e.pageY - rect.top
+      y: e.clientY - rect.top
     }
     return { x: -1, y: -1 }
   }


### PR DESCRIPTION
Protip: use `clientY` instead of `pageY` when handling vertical mouse pos relative to screenspace (aka viewport)